### PR TITLE
Force configuration files to be replaced when upgrading logstash package versions

### DIFF
--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -153,11 +153,12 @@ define logstash::package::install(
   if ($logstash::software_provider == 'package') {
 
     package { $name:
-      ensure   => $package_ensure,
-      name     => $package_name,
-      source   => $pkg_source,
-      provider => $pkg_provider,
-      tag      => 'logstash',
+      ensure      => $package_ensure,
+      name        => $package_name,
+      source      => $pkg_source,
+      provider    => $pkg_provider,
+      tag         => 'logstash',
+      configfiles => 'replace',
     }
 
   } else {


### PR DESCRIPTION
when performing debian package upgrades. 

The parameter is natively supported by puppet's `package` class: https://docs.puppet.com/puppet/latest/types/package.html#package-attribute-configfiles

The default behavior will be to `keep` existing configs, to be consistent with existing behavior.